### PR TITLE
Suggested modifications for age-selectivity type 11

### DIFF
--- a/9control.tex
+++ b/9control.tex
@@ -1823,7 +1823,7 @@ Users are discouraged from using the double logistic selectivity. The double nor
 \myparagraph{Pattern 11 (size or age) - Selectivity = 1.0 for range}
 Length- or age-selectivity can be set equal to 1.0 for a range of lengths or ages. Like other selectivity types, it is specified in terms of the population, not the data bins.
 
-For age-based selectivity, parameters p1 and p2 are set in terms of population age. For example, p1 = 0 and p2 = 4 would mean selectivity of 1.0 for age-0, age-1, age-2, age-3, and age-4 fish. The these parameters must be less than or equal to the maximum age, not the maximum age bin. All ages before and after p1 and p2 have selectivity equal to 0.
+For age-based selectivity, parameters p1 and p2 are set in terms of population age. For example, p1 = 0 and p2 = 4 would mean selectivity of 1.0 for age-0, age-1, age-2, age-3, and age-4 fish. These parameters must be less than or equal to the maximum age, not the maximum age bin. All ages before and after p1 and p2 have selectivity equal to 0.
 
 If the selectivity is length-based, the input parameters should match the population length bin \textbf{number} that will have selectivity = 1.0. A simple example how this works is as follows:
 

--- a/9control.tex
+++ b/9control.tex
@@ -1821,7 +1821,11 @@ Users are discouraged from using the double logistic selectivity. The double nor
 	\end{itemize}
 	
 \myparagraph{Pattern 11 (size or age) - Selectivity = 1.0 for range}
-Length- or age-selectivity can be set equal to 1.0 for a range of lengths or ages. If the selectivity is length-based the input parameters should match the population length bin number that will have selectivity = 1.0. A simple example how this works is as follows:
+Length- or age-selectivity can be set equal to 1.0 for a range of lengths or ages. Like other selectivity types, it is specified in terms of the population, not the data bins.
+
+For age-based selectivity, parameters p1 and p2 are set in terms of population age. For example, p1 = 0 and p2 = 4 would mean selectivity of 1.0 for age-0, age-1, age-2, age-3, and age-4 fish. The these parameters must be less than or equal to the maximum age, not the maximum age bin. All ages before and after p1 and p2 have selectivity equal to 0.
+
+If the selectivity is length-based, the input parameters should match the population length bin \textbf{number} that will have selectivity = 1.0. A simple example how this works is as follows:
 
 \begin{longtable}{p{4cm} p{0.9cm} p{0.9cm} p{0.9cm} p{0.9cm} p{0.9cm} p{0.9cm} p{0.9cm} p{0.9cm}}
 	\hline	
@@ -1835,8 +1839,6 @@ Length- or age-selectivity can be set equal to 1.0 for a range of lengths or age
 	\item p2 The final length-bin to set selectivity equal to 1.0. Using the above bin structure if p2 = 7 then selectivity = 1.0 mid-bin length of 23 cm.
 	\item All length bins before and after p1 and p2 will be set near zero (1e-010).
 \end{itemize}
-
-The age-selectivity approach follows that detailed above for the length-selectivity approach but it is more intuitive because parameter p1 and p2 are set in terms of population age rather than bins that correspond to an age. For example, p1 = 0 and p2 = 4 would mean selectivity of 1.0 for age-0, age-1, age-2, age-3, and age-4 fish. The maximum age allowed is equal to the maximum age in the modelled population, not the maximum age in the data bins.
 
 \myparagraph{Pattern 14 (age) - Revise Age}
 Age-selectivity pattern 14 to allow selectivity-at-age to be the same as selectivity at the next younger age. When using this option, the range on each parameter should be approximately -5 to 9 to prevent the parameters from drifting into extreme values with nil gradient. The age-based selectivity is calculated as $a = 1$ to $a = Amax + 1$:

--- a/9control.tex
+++ b/9control.tex
@@ -1836,7 +1836,7 @@ Length- or age-selectivity can be set equal to 1.0 for a range of lengths or age
 	\item All length bins before and after p1 and p2 will be set near zero (1e-010).
 \end{itemize}
 
-The age-selectivity approach follows that detailed above for length-selectivity but is more intuitive since parameter p1 and p2 is set in terms of population age. 
+The age-selectivity approach follows that detailed above for the length-selectivity approach but it is more intuitive because parameter p1 and p2 are set in terms of population age rather than bins that correspond to an age. For example, p1 = 0 and p2 = 4 would mean selectivity of 1.0 for age-0, age-1, age-2, age-3, and age-4 fish. The maximum age allowed is equal to the maximum age in the modelled population, not the maximum age in the data bins.
 
 \myparagraph{Pattern 14 (age) - Revise Age}
 Age-selectivity pattern 14 to allow selectivity-at-age to be the same as selectivity at the next younger age. When using this option, the range on each parameter should be approximately -5 to 9 to prevent the parameters from drifting into extreme values with nil gradient. The age-based selectivity is calculated as $a = 1$ to $a = Amax + 1$:


### PR DESCRIPTION
when working with age-specific selectivity of 1.0 for a range of ages.

Sorry if I made this pull request to the wrong base branch, i.e., it should not go into main. Feel free to suggest a different branch and I can rebase and submit a different/modified pull request.

The change in wording will be helpful to users that are new to selectivity type = 11. Even though I have used the type before I had to go to the Report.sso to make sure that it was doing what I thought it was. I was not sure if the parameters corresponded to the bins for ages or to the actual age numbers themselves. I also included an example in the suggested text.