### PR TITLE
Remove section referencing TMB model for 2DAR1

### DIFF
--- a/15special.tex
+++ b/15special.tex
@@ -102,25 +102,6 @@ where $\rho_a$ and $\rho_t$ are the among age and among year AR1 coefficients, r
 \epsilon_{a,t}\sim N(0,\sigma_s^2)
 \end{equation} 
 
-\myparagraph{Using the Two-Dimensional Autoregressive Selectivity}
-Note, \citet{xu-new-2019} has additional information on tuning the 2DAR1 selectivity parameters. First, fix the two AR1 coefficients ($\rho_a$ and $\rho_t$) at 0 and tune $\sigma_s$ iteratively to match the relationship:
-
-\begin{equation}
-\sigma_s^2=SD(\epsilon)^2+\frac{1}{(a_{max}-a_{min}+1)(t_{max}-t_{min}+1)}\sum_{a=a_{min}}^{a_{max}}\sum_{t=t_{min}}^{t_{max}}SE(\epsilon_{a,t})^2
-\end{equation}
-
-The minimal and maximal ages/lengths and years for the 2DAR1 process can be freely specified by users in the control file. However, we recommend specifying the minimal and maximal ages and years to cover the relatively ``data-rich'' age/length and year ranges only. Particularly we introduce: 
-
-\begin{equation}
-b=1-\frac{\frac{1}{(a_{max}-a_{min}+1)(t_{max}-t{min}+1)}\sum_{a=a_{min}}^{a_{max}}\sum_{t=t_{min}}^{t_{max}}SE(\epsilon_{a,t})^2}{\sigma_s^2}
-\end{equation}
-
-as a measure of how rich the composition data is regarding estimating selectivity deviations. We also recommend using the Dirichlet-multinomial method to ``weight'' the corresponding composition data while $\sigma_s$ is interactively tuned in this step.
-
-Second, fix $\sigma_s$ at the value iteratively tuned in the previous step and estimate $\epsilon_{a,t}$. Plot both Pearson residuals and $\epsilon_{a,t}$ out on the age-year surface to check their 2D dimensions. If their distributions seems to be not random but rather be autocorrelated (deviation estimates have the same sign several ages and/or years in a row), users should consider estimating and then including the autocorrelations in $\epsilon_{a,t}$.
-
-Third, extract the estimated selectivity deviation samples from the previous step for estimating $\rho_a$ and $\rho_t$ externally by fitting the samples to a stand-alone model written in \gls{tmb}. In this model, both $\rho_a$ and $\rho_t$ are bounded between 0 and 1 via applying a logic transformation. If at least one of the two AR1 coefficients are notably different from 0, the model should be run one more time by fixing the two AR1 coefficients at their values externally estimated from deviation samples. The Pearson residuals and $\epsilon_{a,t}$ from this run are expected to distribute more randomly as the autocorrelations in selectivity deviations can be at least partially included in the 2DAR1 process.
-
 \hypertarget{continuous-seasonal-recruitment-sec}{}
 \subsection[Continuous seasonal recruitment]{\protect\hyperlink{continuous-seasonal-recruitment-sec}{Continuous seasonal recruitment}}
 Setting up a seasonal model such that recruitment can occur with similar and independent probability in any season of any year is awkward in SS3. Instead, SS3 can be set up so that each quarter appears as a year (i.e., a seasons-as-years model). All the data and parameters are set up to treat quarters as if they were years. Note that setting up a seasons-as-years model also requires that all rate parameters be re-scaled to correctly account for the quarters being treated as years.

--- a/ss3_glossaries.tex
+++ b/ss3_glossaries.tex
@@ -26,6 +26,5 @@
 \newacronym{srr}{SRR}{spawner-recruitment relationship}
 \newacronym{ss3}{SS3}{Stock Synthesis}
 \newacronym{ssi}{SSI}{Stock Synthesis Interface}
-\newacronym{tmb}{TMB}{Template Model Builder}
 \newacronym{vlab}{VLab}{NOAA Virtual Lab}
 \newacronym{ypr}{YPR}{yield per recruit}


### PR DESCRIPTION
We were made aware that there was a reference to a TMB model for estimating rho parameters in the 2DAR1 selectivity section of the user manual that we do not support. 

It seems like we will need to delete the entire section of "Using the Two-Dimensional Autoregressive Selectivity" under [section 14.2](https://nmfs-ost.github.io/ss3-doc/SS330_User_Manual_release.html#parameterizing-the-two-dimensional-autoregressive-selectivity) since it goes through a process for tuning the parameters.