### PR TITLE
Find max data-number instead of hard-coded number

### DIFF
--- a/.github/workflows/build-ss3-manual-html.yml
+++ b/.github/workflows/build-ss3-manual-html.yml
@@ -137,13 +137,17 @@ jobs:
           # Add title to references
           where_add <- (grep("references csl-bib-body hanging-indent",
                              html_txt, fixed = TRUE) - 1)
+          dat_num <- grep("data-number", html_txt)
+          dat_num_actual <- html_txt[dat_num]
+          dat_num_actual <- gsub(".*data-number=", "", dat_num_actual)
+          ref_num <- max(as.numeric(sub("\\D*(\\d+).*", "\\1", dat_num_actual))) + 1
           html_txt <- append(html_txt,
-            '<h1 data-number="17" id="sec:references"><span class="header-section-number">17</span> References</h1>',
+            paste0('<h1 data-number="', ref_num, '" id="sec:references"><span class="header-section-number">', ref_num, '</span> References</h1>'),
             after = where_add)
           # Add references to table of contents
           where_add <- grep("</nav>", html_txt, fixed = TRUE)-2
           html_txt <- append(html_txt,
-            '<li><a href="#sec:references"><span class="toc-section-number">17</span> References</a></li>',
+            paste0('<li><a href="#sec:references"><span class="toc-section-number">', ref_num, '</span> References</a></li>'),
             after = where_add)
           writeLines(html_txt, "SS330_User_Manual.html")
         shell: Rscript {0}


### PR DESCRIPTION
Resolves issue pointed out in issue #60 of hard-coded number in html build workflow.