### PR TITLE
Fix typos: now, estimable, Kronecker

### DIFF
--- a/15special.tex
+++ b/15special.tex
@@ -82,7 +82,7 @@ where $S_a$ is specified in the corresponding age/length selectivity types secti
 vec(\epsilon) \sim MVN(\mathbf{0},\sigma_s^2\mathbf{R_{total}})
 \end{equation}
 
-where $\epsilon$ is the two-dimensional deviation matrix and $\sigma_s^2\mathbf{R_{total}}$ is the covariance matrix for the 2DAR process. More specifically, $\sigma_s^2$ quantifies the variance in selectivity deviations and $\mathbf{R_{total}}$ is equal to the kronecker product ($\otimes$) of the two correlation matrices for the among-age and among-year AR processes:
+where $\epsilon$ is the two-dimensional deviation matrix and $\sigma_s^2\mathbf{R_{total}}$ is the covariance matrix for the 2DAR process. More specifically, $\sigma_s^2$ quantifies the variance in selectivity deviations and $\mathbf{R_{total}}$ is equal to the Kronecker product ($\otimes$) of the two correlation matrices for the among-age and among-year AR processes:
 
 \begin{equation}
 \mathbf{R_{total}}=\mathbf{R}\otimes\mathbf{\tilde{R}}

--- a/9control.tex
+++ b/9control.tex
@@ -144,7 +144,7 @@ The capability to read empirical body weight-at-age for the population and each 
 \subsubsection[Settlement Timing for Recruits and Distribution]{\protect\hyperlink{SettlementTiming}{Settlement Timing for Recruits and Distribution}}
 In older versions of SS3 one value of spawning biomass was calculated annually at the beginning of one specified spawning season and this spawning biomass produced one annual total recruitment value. The annual recruitment value was then distributed among seasons, areas, and growth types according to other model parameters.
 
-Additional control of the seasonal timing was added in v.3.30 and now there now is an explicit elapsed time between spawning and recruitment. Spawning still occurs, just once per year, which defines a single spawning biomass for the stock-recruitment curve, but its timing can be at any specified time, not just the beginning of a season. Recruitment of the progeny from an annual spawning can now enter the population in one or more settlement events, at some point after spawning as defined by the user.
+Additional control of the seasonal timing was added in v.3.30 and now there is an explicit elapsed time between spawning and recruitment. Spawning still occurs, just once per year, which defines a single spawning biomass for the stock-recruitment curve, but its timing can be at any specified time, not just the beginning of a season. Recruitment of the progeny from an annual spawning can now enter the population in one or more settlement events, at some point after spawning as defined by the user.
 
 \begin{center}
 	\begin{longtable}{p{1.25cm} p{1.25cm} p{1cm} p{11.5cm}}
@@ -1203,7 +1203,7 @@ The $R_{0}$, steepness, and regime shift parameters can be time-varying by block
 
 \hypertarget{TuneSigmaR}{}
 \subsubsection[Tuning $\sigma_R$]{\protect\hyperlink{TuneSigmaR}{Tuning $\sigma_R$}}
-The $\sigma_R$ value is typically not estimatable and it is recommended practice to tune input $\sigma_R$ values based on the variance in estimated recruitments post running SS3. The R package \href{https://github.com/r4ss/r4ss}{R code for Stock Synthesis (\texttt{r4ss})} designed to read and visualize SS3 model results provides recommendations on adjusting $\sigma_R$ values in the \texttt{sigma\_R\_info} object in the list created by the \texttt{r4ss::SS\_output()} function. An alternative $\sigma_R$ value is provided based on equation:
+The $\sigma_R$ value is typically not estimable and it is recommended practice to tune input $\sigma_R$ values based on the variance in estimated recruitments post running SS3. The R package \href{https://github.com/r4ss/r4ss}{R code for Stock Synthesis (\texttt{r4ss})} designed to read and visualize SS3 model results provides recommendations on adjusting $\sigma_R$ values in the \texttt{sigma\_R\_info} object in the list created by the \texttt{r4ss::SS\_output()} function. An alternative $\sigma_R$ value is provided based on equation:
 
 \begin{equation}
 	\sigma_R^2 = Var(\hat{r}) + \overline{SE(\hat{r}_y)}^2
@@ -1553,7 +1553,7 @@ For each fleet that has index observations, enter a row with six entries as desc
 			\item 2 = no phase adjustments, can be used when profiling on fixed $R_{0}$.
 		\end{itemize}
 	\end{enumerate}
-	\item Extra\_se: Estimatable extra standard error for an index
+	\item Extra\_se: Estimable extra standard error for an index
 	\begin{enumerate}[(a)]
 		\item 0 = skip (typical); and
 		\item 1 = include a parameter that will contain a value to be added to the input standard deviation of the survey variability.


### PR DESCRIPTION
Hi, this pull request fixes the following typos:
* and now there now is -> and now there is
* estimatable -> estimable
* kronecker -> Kronecker