### PR TITLE
Improve Schnute/Richards equations

### DIFF
--- a/9control.tex
+++ b/9control.tex
@@ -502,20 +502,20 @@ with parameters $L_{1}$, $L_\infty$, and $k$. The $L_\infty$ is calculated as:
 based on the input values of fixed age for first size-at-age ($A_1$) and fixed age for second size-at-age ($A_2$). 
 
 \myparagraph{Schnute/Richards growth function}
-The \citet{richards1959growth} growth model as parameterized by \citet{schnute1981growth} provides a flexible growth parameterization that allows for not only asymptotic growth but also linear, quadratic or exponential growth. The Schnute/Richards growth is invoked by entering option 2 in the growth type field. The Schnute/Richards growth function uses the standard growth parameters (e.g., Lmin, Linf, and $k$) and a fourth parameter that is read after reading the von Bertalanffy growth coefficient parameter ($k$). When this fourth parameter has a value of 1.0, it is equivalent to the standard von Bertalanffy growth curve. When this function was first introduced, it was required that A0 parameter be set to 0.0.
+The \citet{richards1959growth} growth model as parameterized by \citet{schnute1981growth} provides a flexible growth parameterization that allows for not only asymptotic growth but also linear, quadratic or exponential growth. The Schnute/Richards growth is invoked by entering option 2 in the growth type field. The Schnute/Richards growth function uses the standard growth parameters ($L_1$, $L_2$, $k$) and a fourth parameter $b$ that is read after reading the von Bertalanffy growth coefficient parameter ($k$). When this fourth parameter has a value of 1.0, it is equivalent to the standard von Bertalanffy growth curve. When this function was first introduced, it was required that the A0 parameter be set to 0.0.
 
 The Schnute/Richards growth model is parameterized as:
 
 \begin{equation}
-		L_t = L_{MIN}^b + (L_\infty^b-L_{MIN}^b)\frac{1-e^{-k(t-A_{1})}}{1-e^{-k(A_2-A_1)}}^{1/b}
+	L_t = \left[L_1^b + (L_2^b-L_1^b)\frac{1-e^{-k(t-A_{1})}}{1-e^{-k(A_2-A_1)}}\right]^{1/b}
 \end{equation}
 
-with parameters $L_{MIN}$, $L_{MAX}$, $k$, and $b$.
+with parameters $L_1$, $L_2$, $k$, and $b$.
 
-The Richards model has $b$ < 0, the von Bertalanffy model has $b$ = 1. The general case of $b$ > 0 was called the ``generalized von Bertalanffy'' by \citet{schnute1981growth}. The Gompertz model has $b$ = 0, where the equation is undefined as written above and must be replaced with: 
+The Richards model has $b<0$, the von Bertalanffy model has $b=1$. The general case of $b>0$ was called the ``generalized von Bertalanffy'' by \citet{schnute1981growth}. The Gompertz model has $b=0$, where the equation is undefined as written above and must be replaced with: 
 
 \begin{equation}
-		L_t = y_1e\Big[ln(y_2/y-1)\frac{1-e^{-k(t-A_1)}}{1-e{-k(A_2-A_1)}}\Big]
+	L_t = L_1\exp\left[\log(L_2/L_1)\frac{1-e^{-k(t-A_1)}}{1-e^{-k(A_2-A_1)}}\right]
 \end{equation}
 
 Thus, if $b$ will be estimated as a free parameter, it might be necessary to include options for constraining it to different ranges.


### PR DESCRIPTION
This pull request improves the Schnute/Richards equations and the surrounding text.

The equations had significant errors, with Eq. 6 missing outer brackets and parts of Eq. 7 that should be subscripted or superscripted. There were also some inconsistencies in parameter names, such as Lmax/Linf/y2 that have been named L2.