### PR TITLE
Update README.md with upper case stock synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ss3-doc
 
-Source code for the stock synthesis manual and other supplementary documentation.
+Source code for the Stock Synthesis (SS3) manual and other supplementary documentation.
 
 ## What documentation is available in this repository?
 


### PR DESCRIPTION
In the  README.md file, it looks better with the first occurrence of Stock Synthese as upper case with the acronym.