### PR TITLE
Revise section on Richards growth function

### DIFF
--- a/9control.tex
+++ b/9control.tex
@@ -501,10 +501,10 @@ with parameters $L_{1}$, $L_\infty$, and $k$. The $L_\infty$ is calculated as:
 
 based on the input values of fixed age for first size-at-age ($A_1$) and fixed age for second size-at-age ($A_2$). 
 
-\myparagraph{Schnute/Richards growth function}
-The \citet{richards1959growth} growth model as parameterized by \citet{schnute1981growth} provides a flexible growth parameterization that allows for not only asymptotic growth but also linear, quadratic or exponential growth. The Schnute/Richards growth is invoked by entering option 2 in the growth type field. The Schnute/Richards growth function uses the standard growth parameters ($L_1$, $L_2$, $k$) and a fourth parameter $b$ that is read after reading the von Bertalanffy growth coefficient parameter ($k$). When this fourth parameter has a value of 1.0, it is equivalent to the standard von Bertalanffy growth curve. When this function was first introduced, it was required that the A0 parameter be set to 0.0.
+\myparagraph{Richards growth function}
+The \citet{richards1959growth} growth model as parameterized by \citet{schnute1981growth} provides a flexible growth parameterization that allows for a variety of growth curve shapes. The Richards growth is invoked by entering option 2 in the growth type field. The Richards growth function uses the standard growth parameters ($L_1$, $L_2$, $k$) and a fourth shape parameter $b$ that is specified after the growth coefficient $k$.
 
-The Schnute/Richards growth model is parameterized as:
+The Richards growth model is parameterized as:
 
 \begin{equation}
 	L_t = \left[L_1^b + (L_2^b-L_1^b)\frac{1-e^{-k(t-A_{1})}}{1-e^{-k(A_2-A_1)}}\right]^{1/b}
@@ -512,13 +512,13 @@ The Schnute/Richards growth model is parameterized as:
 
 with parameters $L_1$, $L_2$, $k$, and $b$.
 
-The Richards model has $b<0$, the von Bertalanffy model has $b=1$. The general case of $b>0$ was called the ``generalized von Bertalanffy'' by \citet{schnute1981growth}. The Gompertz model has $b=0$, where the equation is undefined as written above and must be replaced with: 
+The $b$ shape parameter can be positive or negative but not precisely 0. When estimating $b$ as a floating-point number, there is effectively no risk of the parameter becoming precisely zero during estimation, as long as the initial value is non-zero.
 
-\begin{equation}
-	L_t = L_1\exp\left[\log(L_2/L_1)\frac{1-e^{-k(t-A_1)}}{1-e^{-k(A_2-A_1)}}\right]
-\end{equation}
+As special cases of the Richards growth model, $b\!=\!1$ is von Bertalanffy growth and $b$ near 0 is Gompertz growth. To use a Gompertz growth curve, the $b$ parameter can be fixed at a small value such as 0.0001.
 
-Thus, if $b$ will be estimated as a free parameter, it might be necessary to include options for constraining it to different ranges.
+When $A_1$ is greater than the youngest age in the model, some combinations of Richards growth parameters can lead to undefined (NaN) predicted length for the younger ages. The choice of $A_1$ and $A_2$ will affect the possible growth curve shapes.
+
+The SS3 website includes a vignette providing further technical insights for using the Richards growth model in Stock Synthesis.
 
 	
 \myparagraph{Mean size-at-maximum age}


### PR DESCRIPTION
In light of the findings of Arni and Ian analyzing the Richards growth function in Stock Synthesis (draft [vignette](https://github.com/arni-magnusson/ss3-richards/blob/main/richards.pdf)) and a related question by Larry Jacobson on the Gompertz growth function (forum [message](https://groups.google.com/g/ss3-forum/c/dS-5KOnVjek?pli=1)), I would like to propose a revised text for the Richards growth function in the User Manual.

This pull request makes the following changes:

* Refer to "Richards" rather than "Schnute/Richards" growth function, to simplify and acknowledge that the Schnute parametrization (1981, Eq. 15) produces the same curves as other Richards parametrizations. Also to prevent confusion with the five-parameter Schnute-Richards (1990) growth function, which is quite different.

* Replace the rather old and vague text that "when this function was first introduced, it was required that the A0 parameter be set to 0.0" with similar guidance that "when A1 is greater than the youngest age in the model, some combinations of Richards growth parameters can lead to undefined (NaN) predicted length for the younger ages".

* No longer refer to b<0 as the "Richards" model and b>0 as the "generalized von Bertalanffy" model. In modern parlance, all values of b are the Richards model. The models referred to as Richards growth models by Tjorve and Tjorve (2010) and the [FSA](https://cran.r-project.org/package=FSA) package produce the same curves as the Schnute (1981, Eq. 15) function that is used in Stock Synthesis.

* Guide the user that b should not be set to precisely 0 and that to use the Gompertz growth function, the user can fix the Richards shape parameter at a small value such as b=0.0001. The main Richards equation still applies and there is no real need for showing the equivalent Schnute (1981, Eq. 16) case 2 (Gompertz) function that is not implemented in Stock Synthesis.

* Omit the somewhat unclear guidance that it might be necessary to constrain b to "different ranges". In practice, b will probably be somewhere between -3 and +6, as shown by the corresponding growth curves in the vignette.

* Last, but not least, mention that the SS3 website includes a vignette providing further technical insights for using the Richards growth model in Stock Synthesis.