### PR TITLE
fix(expl3): Removes error checking

### DIFF
--- a/SS330_User_Manual.tex
+++ b/SS330_User_Manual.tex
@@ -1,7 +1,7 @@
 % Preamble =========================================================================================
 %Options added to improve pdf accessibility:
 \RequirePackage{pdfmanagement-testphase}
-\PassOptionsToPackage{enable-debug,check-declarations}{expl3}
+\PassOptionsToPackage{enable-debug}{expl3}
 %\DeclareDocumentMetadata {  }
 \DocumentMetadata{testphase={phase-III,math}}
 \ExplSyntaxOn


### PR DESCRIPTION
expl3 is part of the kernel and we don't need to pass all the options to it, you can probably delete this whole line but I just removed the portion that was leading to the problem. I haven't checked that the pdf looks the same.

close #282 